### PR TITLE
Pin apc-anonymizer library to release tag v0.1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -40,7 +40,7 @@ pyyaml = "^6.0"
 [package.source]
 type = "git"
 url = "https://github.com/tvv-lippu-ja-maksujarjestelma-oy/waltti-apc-vehicle-anonymization-profiler-library.git"
-reference = "HEAD"
+reference = "v0.1.0"
 resolved_reference = "e34b39513a90075489128ff7d45d7f8c338e3833"
 
 [[package]]
@@ -1816,4 +1816,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "137204414134127fba4918acf53a39b3d6615c529d6d775ad77fa8fbd4aa4786"
+content-hash = "19e96f8041b7a9d7f1aef1e543660385ce9dacc0a93b9b6bf9cb46305c232d24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,9 @@ repository = "https://github.com/tvv-lippu-ja-maksujarjestelma-oy/waltti-apc-veh
 packages = [{include = "waltti_apc_vehicle_anonymization_profiler", from = "src"}]
 
 [tool.poetry.dependencies]
-# As the library is used only here, use the master branch directly.
-apc-anonymizer = {git = "https://github.com/tvv-lippu-ja-maksujarjestelma-oy/waltti-apc-vehicle-anonymization-profiler-library.git"}
+# Pin the library to a release tag so lockfile regeneration cannot
+# silently move the privacy engine.
+apc-anonymizer = {git = "https://github.com/tvv-lippu-ja-maksujarjestelma-oy/waltti-apc-vehicle-anonymization-profiler-library.git", tag = "v0.1.0"}
 flask = "^2.3.3"
 google-cloud-logging = "^3.6.0"
 jax = "==0.4.17"


### PR DESCRIPTION
Pins the DP library dependency to tag `v0.1.0` instead of tracking git master (2026-07-07 improvement plan, W3). The tag points at `e34b3951` — the exact commit production already runs, so `resolved_reference` in the lock is unchanged and no rebuild changes behavior. `poetry check --lock` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)